### PR TITLE
refactor: update createTodo function and improve test structure

### DIFF
--- a/front/src/api/todos.ts
+++ b/front/src/api/todos.ts
@@ -28,10 +28,9 @@ const findOneTodo = async (id: number): Promise<Todo> => {
 };
 
 // 할일 생성
-const createTodo = async (title: string): Promise<Todo> => {
+const createTodo = async (title: string): Promise<void> => {
   try {
-    const response = await axiosInstance.post<Todo>(BASE_URL, { title });
-    return response.data;
+    await axiosInstance.post<Todo>(BASE_URL, { title });
   } catch (error) {
     console.error(`Failed to creating todo:`, error);
     throw error;

--- a/front/src/hooks/__test__/useGetTodos.test.tsx
+++ b/front/src/hooks/__test__/useGetTodos.test.tsx
@@ -6,12 +6,12 @@ import { BASE_URL } from '../../api/axios';
 import { server } from '../../mocks/server';
 import useGetTodos from '../queries/useGetTodos';
 
-export const MOCK_TODOS = [
+const MOCK_TODOS = [
   { id: 1, title: '리액트 공부하기', isCompleted: false },
   { id: 2, title: 'TDD 연습하기', isCompleted: false },
 ];
 
-export const wrapper = ({ children }: { children: React.ReactNode }) => {
+const wrapper = ({ children }: { children: React.ReactNode }) => {
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: {


### PR DESCRIPTION
- Changed the return type of createTodo from Promise<Todo> to Promise<void> to reflect that it no longer returns the created todo.
- Updated the test for useMutateCreateTodo to use a more descriptive title for the new todo and ensured proper error handling assertions.
- Refactored the test setup for useGetTodos and useMutateCreateTodo to enhance clarity and maintainability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the `createTodo` functionality to no longer return the created `Todo` object.
  
- **Bug Fixes**
	- Adjusted the test for creating a todo to reflect the new title and handle error messages more accurately.

- **Tests**
	- Simplified test setup for `useGetTodos` and `useMutateCreateTodo` hooks by changing export statuses and streamlining assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->